### PR TITLE
feat: Add sasjs version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ Command Line Interface for SASjs.
 - `create`: creates the folders and files specified in `file-structure.json`, in the current working directory.
 - `build`: loads dependencies and builds services for SAS.
 - `help`: displays help text.
+- `version`: displays the currently installed version of SASjs CLI.

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,4 +1,9 @@
-import { createFileStructure, buildServices, showHelp } from "./main";
+import {
+  createFileStructure,
+  buildServices,
+  showHelp,
+  showVersion
+} from "./main";
 import chalk from "chalk";
 
 function parseCommand(rawArgs) {
@@ -38,6 +43,9 @@ export async function cli(args) {
       break;
     case "help":
       await showHelp();
+      break;
+    case "version":
+      await showVersion();
       break;
     default:
       showInvalidCommandText();

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import { build } from "./sasjs-build";
 import { create } from "./sasjs-create";
 import { printHelpText } from "./sasjs-help";
+import { printVersion } from "./sasjs-version";
 import chalk from "chalk";
 
 export async function createFileStructure(parentFolderName) {
@@ -24,6 +25,10 @@ export async function createFileStructure(parentFolderName) {
 
 export async function showHelp() {
   await printHelpText();
+}
+
+export async function showVersion() {
+  await printVersion();
 }
 
 export async function buildServices() {

--- a/src/sasjs-version/index.js
+++ b/src/sasjs-version/index.js
@@ -1,0 +1,24 @@
+import shelljs from "shelljs";
+import chalk from "chalk";
+
+export async function printVersion() {
+  const result = shelljs.exec(`npm list -g sasjs-cli`, {
+    silent: true
+  });
+
+  const line = result.split("\n").find(l => l.includes("sasjs-cli"));
+  const version = line.split("@")[1].trim();
+  if (version.includes("->")) {
+    console.log(
+      chalk.red(
+        `You are using a linked version of SASjs CLI running from sources at ${chalk.cyanBright(
+          version.replace("->", "").trim()
+        )}`
+      )
+    );
+  } else {
+    console.log(
+      chalk.greenBright(`You are using SASjs CLI v${chalk.cyanBright(version)}`)
+    );
+  }
+}


### PR DESCRIPTION
Invoked using `sasjs version`.

Displays the version number if you've installed `sasjs-cli` globally.
Otherwise displays the path to the linked version running from sources.