### PR TITLE
feat: Support multiple build targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Command line interface for SASjs",
   "main": "index.js",
   "scripts": {
-    "test": "jest",
+    "test": "jest --silent",
     "semantic-release": "semantic-release"
   },
   "bin": {

--- a/src/config.json
+++ b/src/config.json
@@ -84,7 +84,21 @@
       ]
     }
   ],
-  "macroLocations": ["sas"],
-  "useMacroCore": true,
-  "buildFolders": ["services"]
+  "config": {
+    "useMacroCore": true,
+    "macroLocations": ["sas"],
+    "buildFolders": ["services"],
+    "targets": [
+      {
+        "deployScript": "myviyadeploy.sas",
+        "appLoc": "/Public/app",
+        "serverType": "SASVIYA"
+      },
+      {
+        "deployScript": "mysas9deploy.sas",
+        "appLoc": "/Public/app",
+        "serverType": "SAS9"
+      }
+    ]
+  }
 }

--- a/src/sasjs-build/index.js
+++ b/src/sasjs-build/index.js
@@ -71,12 +71,12 @@ async function createFinalSasFile(fileName, appLoc, serverType) {
 }
 
 async function getBuildConfig(appLoc, serverType) {
-  let buildConfig = `%let appLoc=${appLoc}; /* metadata or files service location of your app */\n`;
+  let buildConfig = "";
   const createWebServiceScript = await getCreateWebServiceScript(serverType);
   buildConfig += `${createWebServiceScript}\n`;
   const dependencyFilePaths = await getDependencyPaths(buildConfig);
   const dependenciesContent = await getDependencies(dependencyFilePaths);
-  return `${dependenciesContent}\n${buildConfig}\n`;
+  return `%let appLoc=${appLoc}; /* metadata or files service location of your app */\n${dependenciesContent}\n${buildConfig}\n`;
 }
 
 async function getCreateWebServiceScript(serverType) {

--- a/src/sasjs-create/index.js
+++ b/src/sasjs-create/index.js
@@ -1,27 +1,29 @@
 import path from "path";
 
 import { initNpmProject, asyncForEach } from "../utils/utils";
-import { getFolders } from "../utils/config-utils";
-import { createFolderStructure, createFolder, copy } from "../utils/file-utils";
+import { getFolders, getConfiguration } from "../utils/config-utils";
+import {
+  createFolderStructure,
+  createFolder,
+  createFile
+} from "../utils/file-utils";
 import chalk from "chalk";
 
 export async function create(parentFolderName) {
-  const pathToConfig = path.join(__dirname, "../config.json");
+  const config = await getConfiguration(path.join(__dirname, "../config.json"));
   const fileStructure = await getFileStructure();
   console.log(chalk.greenBright("Creating folders and files..."));
   await createFolder(path.join(process.cwd(), parentFolderName));
   await asyncForEach(fileStructure, async (folder, index) => {
     await createFolderStructure(folder, parentFolderName);
     if (index === 0) {
-      await copy(
-        pathToConfig,
-        path.join(
-          process.cwd(),
-          parentFolderName,
-          folder.folderName,
-          "config.json"
-        )
+      const configDestinationPath = path.join(
+        process.cwd(),
+        parentFolderName,
+        folder.folderName,
+        "config.json"
       );
+      await createFile(configDestinationPath, JSON.stringify(config, null, 1));
     }
   });
   await initNpmProject(path.join(process.cwd(), parentFolderName));

--- a/src/sasjs-create/index.js
+++ b/src/sasjs-create/index.js
@@ -1,13 +1,13 @@
 import path from "path";
 
 import { initNpmProject, asyncForEach } from "../utils/utils";
-import { getConfiguration } from "../utils/config-utils";
+import { getFolders } from "../utils/config-utils";
 import { createFolderStructure, createFolder, copy } from "../utils/file-utils";
 import chalk from "chalk";
 
 export async function create(parentFolderName) {
   const pathToConfig = path.join(__dirname, "../config.json");
-  const fileStructure = await getFileStructure(pathToConfig);
+  const fileStructure = await getFileStructure();
   console.log(chalk.greenBright("Creating folders and files..."));
   await createFolder(path.join(process.cwd(), parentFolderName));
   await asyncForEach(fileStructure, async (folder, index) => {
@@ -27,7 +27,6 @@ export async function create(parentFolderName) {
   await initNpmProject(path.join(process.cwd(), parentFolderName));
 }
 
-async function getFileStructure(pathToFile) {
-  const configuration = await getConfiguration(pathToFile);
-  return Promise.resolve(configuration.folders);
+async function getFileStructure() {
+  return await getFolders();
 }

--- a/src/utils/config-utils.js
+++ b/src/utils/config-utils.js
@@ -5,7 +5,7 @@ export async function getConfiguration(pathToFile) {
   const config = await readFile(pathToFile);
   if (config) {
     const configJson = JSON.parse(config);
-    return Promise.resolve(configJson.config);
+    return Promise.resolve(configJson.config ? configJson.config : configJson);
   }
   return Promise.reject();
 }
@@ -32,6 +32,13 @@ export async function getSourcePaths() {
   }
 
   return sourcePaths;
+}
+
+export async function getBuildTargets() {
+  const configuration = await getConfiguration(
+    path.join(process.cwd(), "sas", "config.json")
+  );
+  return configuration.targets;
 }
 
 export function getMacroCorePath() {

--- a/src/utils/config-utils.js
+++ b/src/utils/config-utils.js
@@ -5,7 +5,16 @@ export async function getConfiguration(pathToFile) {
   const config = await readFile(pathToFile);
   if (config) {
     const configJson = JSON.parse(config);
-    return Promise.resolve(configJson);
+    return Promise.resolve(configJson.config);
+  }
+  return Promise.reject();
+}
+
+export async function getFolders() {
+  const config = await readFile(path.join(__dirname, "../config.json"));
+  if (config) {
+    const configJson = JSON.parse(config);
+    return Promise.resolve(configJson.folders);
   }
   return Promise.reject();
 }


### PR DESCRIPTION
Fixes https://github.com/macropeople/sasjs-cli/issues/12

* Generated `config.json` now only includes the configuration, the folder structure has been removed.
* We now generate one script per build target, named as per the target's configuration.
* The scripts include the correct macro for building the web service for the given server type.