### PR TITLE
`sasjs create` with existing NPM projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Command Line Interface for SASjs.
 
 - `create`: creates the folders and files required for SAS development. You can use this command in two ways:
   1. `sasjs create folderName` - which creates a new folder with the name specified.
-  2. `sasjs create` - which creates the files and folder in the current working directory. Please note that this directory must be an existing NPM project with a `package.json` file.
+  2. `sasjs create` - which creates the files and folder in the current working directory. If this directory is an existing NPM project with a `package.json` file, this command adds `macrocore` to the list of dependencies in that file. Else, it will initialise a new NPM project and then install `macrocore`.
 - `build`: loads dependencies and builds services for SAS.
 - `help`: displays help text.
 - `version`: displays the currently installed version of SASjs CLI.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Command Line Interface for SASjs.
 
 ## Available Options
 
-- `create`: creates the folders and files specified in `file-structure.json`, in the current working directory.
+- `create`: creates the folders and files required for SAS development. You can use this command in two ways:
+  1. `sasjs create folderName` - which creates a new folder with the name specified.
+  2. `sasjs create` - which creates the files and folder in the current working directory. Please note that this directory must be an existing NPM project with a `package.json` file.
 - `build`: loads dependencies and builds services for SAS.
 - `help`: displays help text.
 - `version`: displays the currently installed version of SASjs CLI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4936,6 +4936,12 @@
       "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA==",
       "dev": true
     },
+    "macrocore": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/macrocore/-/macrocore-1.5.2.tgz",
+      "integrity": "sha512-ysd50RaOLH+jW1EOjzIWSyWcwqPwilEGzBw1Nd7vKPcYs8+1ICddxlfMjkvePRdszHVCVRRgV/Yp3u9Q2Nox0g==",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@babel/preset-env": "^7.8.7",
     "babel-jest": "^25.1.0",
     "jest-cli": "^25.1.0",
+    "macrocore": "^1.5.2",
     "semantic-release": "^17.0.4"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -9,7 +9,9 @@ export async function createFileStructure(parentFolderName) {
     .then(() =>
       console.log(
         chalk.greenBright.bold.italic(
-          `Project ${parentFolderName} created successfully.\nGet ready to Unleash your SAS!`
+          `Project ${
+            parentFolderName ? `${parentFolderName} created` : `updated`
+          } successfully.\nGet ready to Unleash your SAS!`
         )
       )
     )

--- a/src/utils/file-utils.js
+++ b/src/utils/file-utils.js
@@ -4,7 +4,7 @@ import fsExtra from "fs-extra";
 import rimraf from "rimraf";
 import path from "path";
 
-export async function createFolderStructure(folder, parentFolderName = "") {
+export async function createFolderStructure(folder, parentFolderName = ".") {
   let folderPath = path.join(process.cwd(), folder.folderName);
   if (parentFolderName) {
     folderPath = path.join(process.cwd(), parentFolderName, folder.folderName);
@@ -42,6 +42,12 @@ export async function createFolderStructure(folder, parentFolderName = "") {
       await createFolderStructure(subFolder);
     });
   }
+}
+
+export async function fileExists(filePath) {
+  return new Promise((resolve, _) => {
+    fs.exists(filePath, exists => resolve(exists));
+  });
 }
 
 export async function readFile(fileName, debug = false) {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,17 +1,31 @@
 import shelljs from "shelljs";
 import chalk from "chalk";
+import path from "path";
+import { fileExists } from "./file-utils";
 
-export function initNpmProject(folderPath) {
-  return new Promise((resolve, _) => {
-    console.log(
-      chalk.greenBright(
-        "Initialising NPM project in",
-        chalk.cyanBright(folderPath)
-      )
-    );
-    shelljs.exec(`cd ${folderPath} && npm init --yes`, {
-      silent: true
-    });
+async function inExistingProject(folderPath) {
+  const packageJsonExists = await fileExists(
+    path.join(process.cwd(), folderPath, "package.json")
+  );
+  return packageJsonExists;
+}
+
+export async function setupNpmProject(folderPath) {
+  return new Promise(async (resolve, _) => {
+    const isExistingProject = await inExistingProject(folderPath);
+    if (!isExistingProject) {
+      console.log(
+        chalk.greenBright(
+          "Initialising NPM project in",
+          chalk.cyanBright(folderPath)
+        )
+      );
+      shelljs.exec(`cd ${folderPath} && npm init --yes`, {
+        silent: true
+      });
+    } else {
+      console.log(chalk.greenBright("Existing NPM project detected.\n"));
+    }
     console.log(chalk.greenBright("Installing MacroCore"));
     shelljs.exec(`cd ${folderPath} && npm i macrocore --save`, {
       silent: true


### PR DESCRIPTION
Fixes https://github.com/macropeople/sasjs-cli/issues/16

# Intent
Add the ability to use `sasjs create` without specifying a folder name. This must create the folder structure in the current directory, and add `macrocore` to the dependencies in the existing `package.json`.

# Implementation
* Modified `sasjs-create` command to assume the default path as `.`, i.e. the current working directory.
* Error out if any folder already exists.
* Modified `setupNpmProject()` to skip `npm init` if we are in an existing project.

## `sasjs create folderName`
![image](https://user-images.githubusercontent.com/2980428/76684065-b622f980-6600-11ea-8181-3ab997f76488.png)

## `sasjs create` in existing NPM project
![image](https://user-images.githubusercontent.com/2980428/76684089-e7032e80-6600-11ea-9085-fec70945001b.png)

## `sasjs create` in existing non-NPM folder
![image](https://user-images.githubusercontent.com/2980428/76684110-1fa30800-6601-11ea-9ad6-56bc03ca44a5.png)

## `sasjs create` when path already exists
![image](https://user-images.githubusercontent.com/2980428/76684126-419c8a80-6601-11ea-87d9-012aa5b2ad5e.png)

