### PR TITLE
Feat: `sasjs web` and `sasjs build targetName` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Command Line Interface for SASjs.
 - `create`: creates the folders and files required for SAS development. You can use this command in two ways:
   1. `sasjs create folderName` - which creates a new folder with the name specified.
   2. `sasjs create` - which creates the files and folder in the current working directory. If this directory is an existing NPM project with a `package.json` file, this command adds `macrocore` to the list of dependencies in that file. Else, it will initialise a new NPM project and then install `macrocore`.
-- `build`: loads dependencies and builds services for SAS.
+- `build targetName`: loads dependencies and builds services for SAS, for the specified build target name. If no target is specified, it builds the first target specified in `config.json`.
+- `web`: generates SAS services for streaming your HTML, CSS and JavaScript-based app from a SAS server. This command is automatically run as part of `sasjs build` if `streamWeb` is set to true for a particular build target.
 - `help`: displays help text.
 - `version`: displays the currently installed version of SASjs CLI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5216,7 +5216,8 @@
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "dev": true
     },
     "node-html-parser": {
       "version": "1.2.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3672,6 +3672,11 @@
         }
       }
     },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+    },
     "hook-std": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
@@ -5211,8 +5216,15 @@
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-      "dev": true
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "node-html-parser": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-1.2.12.tgz",
+      "integrity": "sha512-HnmSRgHz+nhXfaii1KBNGwtGBx8ClLZ+GDQHAUNJ43YR3krfJMSMcMwFW8qwrHioPJaiaZ6xrDkcGjlffF0rnw==",
+      "requires": {
+        "he": "1.1.1"
+      }
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1000,9 +1000,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -4746,9 +4746,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -9301,9 +9301,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         }
       }
@@ -9821,9 +9821,9 @@
           }
         },
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "dev": true
         },
         "normalize-path": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "find": "^0.3.0",
     "fs": "0.0.1-security",
     "fs-extra": "^8.1.0",
-    "node-fetch": "^2.6.0",
     "node-html-parser": "^1.2.12",
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.3"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "find": "^0.3.0",
     "fs": "0.0.1-security",
     "fs-extra": "^8.1.0",
+    "node-fetch": "^2.6.0",
+    "node-html-parser": "^1.2.12",
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.3"
   },

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,7 +2,8 @@ import {
   createFileStructure,
   buildServices,
   showHelp,
-  showVersion
+  showVersion,
+  buildWebApp
 } from "./main";
 import chalk from "chalk";
 
@@ -46,6 +47,9 @@ export async function cli(args) {
       break;
     case "version":
       await showVersion();
+      break;
+    case "web":
+      await buildWebApp();
       break;
     default:
       showInvalidCommandText();

--- a/src/cli.js
+++ b/src/cli.js
@@ -40,7 +40,7 @@ export async function cli(args) {
       await createFileStructure(command.parameters);
       break;
     case "build":
-      await buildServices();
+      await buildServices(command.parameters);
       break;
     case "help":
       await showHelp();

--- a/src/config.json
+++ b/src/config.json
@@ -51,13 +51,13 @@
               "fileName": "yetanothermacro.sas",
               "content": "/**\n  @file yetanothermacro.sas\n  @brief Yet another example of a macro to be used in a service\n  @details  This macro is also great. Yadda yadda yadda. \n\n  <h4> Dependencies </h4>\n  @li doesnothing.sas\n\n**/\n\n%macro yetanothermacro();\n\nproc sort data= areas nodupkey;\n by area;\nrun;\n%doesnothing()\n\n%mend;\n"
             },
-             {
+            {
               "fileName": "doesnothing.sas",
               "content": "%macro doesnothing();\n%put check this, nothing happened!; \n%mend;\n"
             },
             {
               "fileName": "sasjsout.sas",
-              "content": "%macro sasjsout(type,fref=sasjs);\n%global sysprocessmode;\n%if "&sysprocessmode"="SAS Object Server" %then %do;\n  %if &type=HTML %then %do;\n    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name="_webout.json"\n      contenttype="text/html";\n  %end;\n  %else %if &type=JS %then %do;\n    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name='_webout.js'\n      contenttype='application/javascript';\n  %end;\n%end;\n%else %do;\n\n  %if &type=JS %then %do;\n    %let rc=%sysfunc(stpsrv_header(Content-type,application/javascript));\n  %end;\n%end;\ndata _null_;\n  infile &fref RECFM=N;\n  file _webout RECFM=N;\n  input string $CHAR1. @;\n  put string $CHAR1. @;\nrun;\n%mend;\n"
+              "content": "%macro sasjsout(type,fref=sasjs);\n%global sysprocessmode;\n%if \"&sysprocessmode\"=\"SAS Object Server\" %then %do;\n  %if &type=HTML %then %do;\n    filename _webout filesrvc parenturi=\"&SYS_JES_JOB_URI\" name=\"_webout.json\"\n      contenttype=\"text/html\";\n  %end;\n  %else %if &type=JS %then %do;\n    filename _webout filesrvc parenturi=\"&SYS_JES_JOB_URI\" name='_webout.js'\n      contenttype='application/javascript';\n  %end;\n%end;\n%else %do;\n\n  %if &type=JS %then %do;\n    %let rc=%sysfunc(stpsrv_header(Content-type,application/javascript));\n  %end;\n%end;\ndata _null_;\n  infile &fref RECFM=N;\n  file _webout RECFM=N;\n  input string $CHAR1. @;\n  put string $CHAR1. @;\nrun;\n%mend;\n"
             }
           ]
         },
@@ -104,12 +104,18 @@
       {
         "deployScript": "myviyadeploy.sas",
         "appLoc": "/Public/app",
-        "serverType": "SASVIYA"
+        "serverType": "SASVIYA",
+        "streamWeb": true,
+        "streamWebFolder": "webv",
+        "webSourcePath": ""
       },
       {
         "deployScript": "mysas9deploy.sas",
         "appLoc": "/User Folders/&sysuserid/My Folder",
-        "serverType": "SAS9"
+        "serverType": "SAS9",
+        "streamWeb": true,
+        "streamWebFolder": "web9",
+        "webSourcePath": ""
       }
     ]
   }

--- a/src/config.json
+++ b/src/config.json
@@ -102,6 +102,7 @@
     "buildFolders": ["services"],
     "targets": [
       {
+        "name": "viya",
         "deployScript": "myviyadeploy.sas",
         "appLoc": "/Public/app",
         "serverType": "SASVIYA",
@@ -110,6 +111,7 @@
         "webSourcePath": ""
       },
       {
+        "name": "sas9",
         "deployScript": "mysas9deploy.sas",
         "appLoc": "/User Folders/&sysuserid/My Folder",
         "serverType": "SAS9",

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ import { build } from "./sasjs-build";
 import { create } from "./sasjs-create";
 import { printHelpText } from "./sasjs-help";
 import { printVersion } from "./sasjs-version";
+import { createWebAppServices } from "./sasjs-web";
 import chalk from "chalk";
 
 export async function createFileStructure(parentFolderName) {
@@ -47,6 +48,27 @@ export async function buildServices() {
     .catch(err => {
       console.log(
         chalk.redBright("An error has occurred when building services.", err)
+      );
+    });
+}
+
+export async function buildWebApp() {
+  await createWebAppServices()
+    .then(() =>
+      console.log(
+        chalk.greenBright.bold.italic(
+          `Web app services have been successfully built!\nThe build output is located in the ${chalk.cyanBright(
+            "sasbuild"
+          )} directory.`
+        )
+      )
+    )
+    .catch(err => {
+      console.log(
+        chalk.redBright(
+          "An error has occurred when building web app services.",
+          err
+        )
       );
     });
 }

--- a/src/main.js
+++ b/src/main.js
@@ -34,8 +34,8 @@ export async function showVersion() {
   await printVersion();
 }
 
-export async function buildServices() {
-  await build()
+export async function buildServices(targetName) {
+  await build(targetName)
     .then(() =>
       console.log(
         chalk.greenBright.bold.italic(

--- a/src/sasjs-build/index.js
+++ b/src/sasjs-build/index.js
@@ -1,6 +1,7 @@
 import find from "find";
 import path from "path";
 import chalk from "chalk";
+import { createWebAppServices } from "../sasjs-web";
 import {
   readFile,
   getSubFoldersInFolder,
@@ -50,9 +51,27 @@ export async function build() {
 
 async function createFinalSasFiles() {
   const buildTargets = await getBuildTargets();
-  asyncForEach(buildTargets, async target => {
+  await asyncForEach(buildTargets, async target => {
     const { deployScript, appLoc, serverType } = target;
-    createFinalSasFile(deployScript, appLoc, serverType);
+    if (target.streamWeb) {
+      await createWebAppServices([target])
+        .then(() =>
+          console.log(
+            chalk.greenBright.bold.italic(
+              `Web app services have been successfully built!`
+            )
+          )
+        )
+        .catch(err => {
+          console.log(
+            chalk.redBright(
+              "An error has occurred when building web app services.",
+              err
+            )
+          );
+        });
+    }
+    await createFinalSasFile(deployScript, appLoc, serverType);
   });
 }
 

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -20,6 +20,7 @@ export async function createWebAppServices() {
     const webAppSourcePath = await target.webSourcePath;
     const destinationPath = path.join(
       buildDestinationFolder,
+      "services",
       target.streamWebFolder
     );
     await createTargetDestinationFolder(target.streamWebFolder);
@@ -96,7 +97,7 @@ async function createBuildDestinationFolder() {
 }
 
 async function createTargetDestinationFolder(name) {
-  const destinationPath = path.join(buildDestinationFolder, name);
+  const destinationPath = path.join(buildDestinationFolder, "services", name);
   const pathExists = await fileExists(destinationPath);
   if (!pathExists) {
     await createFolder(destinationPath);

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -71,6 +71,34 @@ export async function createWebAppServices(targets = []) {
           finalIndexHtml += `\n${scriptTag}`;
         }
       });
+      // const styleSheetPaths = getStyleSheetPaths(indexHtml);
+      // await asyncForEach(styleSheetPaths, async styleSheetPath => {
+      //   const isUrl = styleSheetPath.startsWith("http");
+      //   const fileName = `${path.basename(styleSheetPath).replace(/\./g, "")}`;
+      //   let content = "";
+
+      //   if (isUrl) {
+      //     const linkTag = `<link rel="stylesheet" href="${styleSheetPath}" />`;
+      //     finalIndexHtml += `\n${linkTag}`;
+      //   } else {
+      //     content = await readFile(
+      //       path.join(process.cwd(), webAppSourcePath, styleSheetPath)
+      //     );
+      //     const serviceContent = await getWebServiceContent(content);
+
+      //     await createFile(
+      //       path.join(destinationPath, `${fileName}.sas`),
+      //       serviceContent
+      //     );
+      //     const scriptTag = getScriptTag(
+      //       target.appLoc,
+      //       target.serverType,
+      //       target.streamWebFolder,
+      //       fileName
+      //     );
+      //     finalIndexHtml += `\n${scriptTag}`;
+      //   }
+      // });
       finalIndexHtml += "</head>";
       finalIndexHtml += `<body>${
         indexHtml.querySelector("body").innerHTML
@@ -94,7 +122,7 @@ function getScriptTag(appLoc, serverType, streamWebFolder, fileName) {
   const storedProcessPath =
     serverType === "SASVIYA"
       ? `/SASJobExecution?_PROGRAM=${appLoc}/${streamWebFolder}`
-      : `/SASStoredProcess?_PROGRAM=${appLoc}/${streamWebFolder}`;
+      : `/SASStoredProcess/?_PROGRAM=${appLoc}/${streamWebFolder}`;
   return `<script src="${storedProcessPath}/${fileName}"></script>`;
 }
 
@@ -104,6 +132,15 @@ function getScriptPaths(parsedHtml) {
     .map(s => s.getAttribute("src"));
 
   return scriptSources;
+}
+
+function getStyleSheetPaths(parsedHtml) {
+  const styleSheetUrls = parsedHtml
+    .querySelectorAll("link")
+    .filter(s => s.getAttribute("rel") === "stylesheet")
+    .map(s => s.getAttribute("href"));
+
+  return styleSheetUrls;
 }
 
 async function createBuildDestinationFolder() {

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -29,7 +29,7 @@ export async function createWebAppServices(targets = []) {
     console.log(
       chalk.greenBright(`Building for target ${chalk.cyanBright(target.name)}`)
     );
-    const webAppSourcePath = await target.webSourcePath;
+    const webAppSourcePath = target.webSourcePath;
     const destinationPath = path.join(
       buildDestinationFolder,
       "services",

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -71,34 +71,34 @@ export async function createWebAppServices(targets = []) {
           finalIndexHtml += `\n${scriptTag}`;
         }
       });
-      // const styleSheetPaths = getStyleSheetPaths(indexHtml);
-      // await asyncForEach(styleSheetPaths, async styleSheetPath => {
-      //   const isUrl = styleSheetPath.startsWith("http");
-      //   const fileName = `${path.basename(styleSheetPath).replace(/\./g, "")}`;
-      //   let content = "";
+      const styleSheetPaths = getStyleSheetPaths(indexHtml);
+      await asyncForEach(styleSheetPaths, async styleSheetPath => {
+        const isUrl = styleSheetPath.startsWith("http");
+        const fileName = `${path.basename(styleSheetPath).replace(/\./g, "")}`;
+        let content = "";
 
-      //   if (isUrl) {
-      //     const linkTag = `<link rel="stylesheet" href="${styleSheetPath}" />`;
-      //     finalIndexHtml += `\n${linkTag}`;
-      //   } else {
-      //     content = await readFile(
-      //       path.join(process.cwd(), webAppSourcePath, styleSheetPath)
-      //     );
-      //     const serviceContent = await getWebServiceContent(content);
+        if (isUrl) {
+          const linkTag = `<link rel="stylesheet" href="${styleSheetPath}" />`;
+          finalIndexHtml += `\n${linkTag}`;
+        } else {
+          content = await readFile(
+            path.join(process.cwd(), webAppSourcePath, styleSheetPath)
+          );
+          const serviceContent = await getWebServiceContent(content, "CSS");
 
-      //     await createFile(
-      //       path.join(destinationPath, `${fileName}.sas`),
-      //       serviceContent
-      //     );
-      //     const scriptTag = getScriptTag(
-      //       target.appLoc,
-      //       target.serverType,
-      //       target.streamWebFolder,
-      //       fileName
-      //     );
-      //     finalIndexHtml += `\n${scriptTag}`;
-      //   }
-      // });
+          await createFile(
+            path.join(destinationPath, `${fileName}.sas`),
+            serviceContent
+          );
+          const scriptTag = getScriptTag(
+            target.appLoc,
+            target.serverType,
+            target.streamWebFolder,
+            fileName
+          );
+          finalIndexHtml += `\n${scriptTag}`;
+        }
+      });
       finalIndexHtml += "</head>";
       finalIndexHtml += `<body>${
         indexHtml.querySelector("body").innerHTML
@@ -158,7 +158,7 @@ async function createTargetDestinationFolder(destinationPath) {
   await createFolder(destinationPath);
 }
 
-async function getWebServiceContent(content) {
+async function getWebServiceContent(content, type = "JS") {
   const lines = content.split("\n").filter(l => !!l);
   let serviceContent = `${sasjsout}\nfilename sasjs temp lrecl=132006;
 data _null_;
@@ -183,7 +183,7 @@ file sasjs;
     }
   });
 
-  serviceContent += "\nrun;\n%sasjsout(JS)";
+  serviceContent += `\nrun;\n%sasjsout(${type})`;
   return serviceContent;
 }
 

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -1,0 +1,92 @@
+import { getBuildTargets } from "../utils/config-utils";
+import { asyncForEach } from "../utils/utils";
+import {
+  readFile,
+  fileExists,
+  createFolder,
+  createFile
+} from "../utils/file-utils";
+import path from "path";
+import { parse } from "node-html-parser";
+import fetch from "node-fetch";
+
+const buildDestinationFolder = path.join(process.cwd(), "sasbuild");
+
+export async function createWebAppServices() {
+  await createBuildDestinationFolder();
+  const buildTargets = await getBuildTargets();
+  await asyncForEach(buildTargets, async target => {
+    const webAppSourcePath = await target.webSourcePath;
+    const destinationPath = path.join(
+      buildDestinationFolder,
+      target.streamWebFolder
+    );
+    await createTargetDestinationFolder(target.streamWebFolder);
+
+    if (webAppSourcePath) {
+      const indexHtml = await readFile(
+        path.join(process.cwd(), webAppSourcePath, "index.html")
+      ).then(parse);
+      let finalIndexHtml = "<!DOCTYPE html>\n<html>\n";
+
+      const scriptPaths = getScriptPaths(indexHtml);
+      await asyncForEach(scriptPaths, async scriptPath => {
+        const isUrl = scriptPath.startsWith("http");
+        const fileName = `${path.basename(scriptPath).replace(/\./g, "")}`;
+        let content = "";
+
+        if (isUrl) {
+          content = await fetch(scriptPath).then(r => r.text());
+        } else {
+          content = await readFile(
+            path.join(process.cwd(), webAppSourcePath, scriptPath)
+          );
+        }
+
+        const serviceContent = await getWebServiceContent(fileName, content);
+
+        await createFile(
+          path.join(destinationPath, `${fileName}.sas`),
+          serviceContent
+        );
+      });
+    }
+  });
+}
+
+function getScriptPaths(parsedHtml) {
+  const scriptSources = parsedHtml
+    .querySelectorAll("script")
+    .map(s => s.getAttribute("src"));
+
+  return scriptSources;
+}
+
+async function createBuildDestinationFolder() {
+  const pathExists = await fileExists(buildDestinationFolder);
+  if (!pathExists) {
+    await createFolder(buildDestinationFolder);
+  }
+}
+
+async function createTargetDestinationFolder(name) {
+  const destinationPath = path.join(buildDestinationFolder, name);
+  const pathExists = await fileExists(destinationPath);
+  if (!pathExists) {
+    await createFolder(destinationPath);
+  }
+}
+
+async function getWebServiceContent(fileName, content) {
+  const lines = content.split("\n");
+  let serviceContent = `filename ${fileName} temp lrecl=132006;
+data _null_;
+file sasjs;
+`;
+  lines.forEach(line => {
+    serviceContent += `put '${line}';\n`;
+  });
+
+  serviceContent += "\nrun;\n%sasjsout(JS)";
+  return serviceContent;
+}

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -10,7 +10,6 @@ import {
 import path from "path";
 import chalk from "chalk";
 import { parse } from "node-html-parser";
-import fetch from "node-fetch";
 import { sasjsout } from "./sasjsout";
 
 const buildDestinationFolder = path.join(process.cwd(), "sasbuild");
@@ -100,9 +99,7 @@ export async function createWebAppServices(targets = []) {
         }
       });
       finalIndexHtml += "</head>";
-      finalIndexHtml += `<body>${
-        indexHtml.querySelector("body").innerHTML
-      }</body></html>`;
+      finalIndexHtml += `${indexHtml.querySelector("body")}</html>`;
       await createClickMeService(finalIndexHtml);
     } else {
       throw new Error(

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -74,7 +74,7 @@ export async function createWebAppServices(targets = []) {
       finalIndexHtml += `<body>${
         indexHtml.querySelector("body").innerHTML
       }</body></html>`;
-      await createClickMeService(finalIndexHtml, target.name);
+      await createClickMeService(finalIndexHtml);
     } else {
       throw new Error(
         "webSourcePath has not been specified. Please check your config and try again."
@@ -122,7 +122,7 @@ async function createTargetDestinationFolder(destinationPath) {
 
 async function getWebServiceContent(fileName, content) {
   const lines = content.split("\n");
-  let serviceContent = `${sasjsout}\nfilename ${fileName} temp lrecl=132006;
+  let serviceContent = `${sasjsout}\nfilename sasjs temp lrecl=132006;
 data _null_;
 file sasjs;
 `;
@@ -156,7 +156,7 @@ function chunk(text, maxLength = 120) {
   return text.match(new RegExp(".{1," + maxLength + "}", "g"));
 }
 
-async function createClickMeService(indexHtmlContent, buildTargetName) {
+async function createClickMeService(indexHtmlContent) {
   const lines = indexHtmlContent.split("\n");
   let clickMeServiceContent = `${sasjsout}\nfilename sasjs temp lrecl=132006;\ndata _null_;\nfile sasjs;\n`;
 

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -4,7 +4,8 @@ import {
   readFile,
   fileExists,
   createFolder,
-  createFile
+  createFile,
+  deleteFolder
 } from "../utils/file-utils";
 import path from "path";
 import chalk from "chalk";
@@ -34,7 +35,7 @@ export async function createWebAppServices(targets = []) {
       "services",
       target.streamWebFolder
     );
-    await createTargetDestinationFolder(target.streamWebFolder);
+    await createTargetDestinationFolder(destinationPath);
 
     if (webAppSourcePath) {
       const indexHtml = await readFile(
@@ -107,12 +108,12 @@ async function createBuildDestinationFolder() {
   }
 }
 
-async function createTargetDestinationFolder(name) {
-  const destinationPath = path.join(buildDestinationFolder, "services", name);
+async function createTargetDestinationFolder(destinationPath) {
   const pathExists = await fileExists(destinationPath);
-  if (!pathExists) {
-    await createFolder(destinationPath);
+  if (pathExists) {
+    await deleteFolder(destinationPath);
   }
+  await createFolder(destinationPath);
 }
 
 async function getWebServiceContent(fileName, content) {
@@ -160,7 +161,7 @@ async function createClickMeService(indexHtmlContent, buildTargetName) {
   });
   clickMeServiceContent += "run;\n%sasjsout(HTML)";
   await createFile(
-    path.join(buildDestinationFolder, "services", `clickme.${buildTargetName}`),
+    path.join(buildDestinationFolder, "services", "clickme.sas"),
     clickMeServiceContent
   );
 }

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -7,16 +7,27 @@ import {
   createFile
 } from "../utils/file-utils";
 import path from "path";
+import chalk from "chalk";
 import { parse } from "node-html-parser";
 import fetch from "node-fetch";
 import { sasjsout } from "./sasjsout";
 
 const buildDestinationFolder = path.join(process.cwd(), "sasbuild");
 
-export async function createWebAppServices() {
+export async function createWebAppServices(targets = []) {
+  console.log(chalk.greenBright("Building web app services..."));
   await createBuildDestinationFolder();
-  const buildTargets = await getBuildTargets();
+  let buildTargets = [];
+  if (!targets.length) {
+    buildTargets = await getBuildTargets();
+  } else {
+    buildTargets = [...targets];
+  }
+
   await asyncForEach(buildTargets, async target => {
+    console.log(
+      chalk.greenBright(`Building for target ${chalk.cyanBright(target.name)}`)
+    );
     const webAppSourcePath = await target.webSourcePath;
     const destinationPath = path.join(
       buildDestinationFolder,

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -129,11 +129,11 @@ file sasjs;
   lines.forEach(line => {
     const chunkedLines = chunk(line);
     if (chunkedLines.length === 1) {
-      serviceContent += `put '${chunkedLines[0]}';\n`;
+      serviceContent += `put '${chunkedLines[0].split("'").join("''")}';\n`;
     } else {
       let combinedLines = "";
       chunkedLines.forEach((chunkedLine, index) => {
-        let text = `put '${chunkedLine}'`;
+        let text = `put '${chunkedLine.split("'").join("''")}'`;
         if (index !== chunkedLines.length - 1) {
           text += "@;\n";
         } else {

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -121,7 +121,7 @@ async function createTargetDestinationFolder(destinationPath) {
 }
 
 async function getWebServiceContent(fileName, content) {
-  const lines = content.split("\n");
+  const lines = content.split("\n").filter(l => !!!l);
   let serviceContent = `${sasjsout}\nfilename sasjs temp lrecl=132006;
 data _null_;
 file sasjs;
@@ -153,7 +153,9 @@ function chunk(text, maxLength = 120) {
   if (text.length <= maxLength) {
     return [text];
   }
-  return text.match(new RegExp(".{1," + maxLength + "}", "g"));
+  return text
+    .match(new RegExp(".{1," + maxLength + "}", "g"))
+    .filter(m => !!!m);
 }
 
 async function createClickMeService(indexHtmlContent) {

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -89,13 +89,13 @@ export async function createWebAppServices(targets = []) {
             path.join(destinationPath, `${fileName}.sas`),
             serviceContent
           );
-          const scriptTag = getScriptTag(
+          const linkTag = getLinkTag(
             target.appLoc,
             target.serverType,
             target.streamWebFolder,
             fileName
           );
-          finalIndexHtml += `\n${scriptTag}`;
+          finalIndexHtml += `\n${linkTag}`;
         }
       });
       finalIndexHtml += "</head>";
@@ -121,6 +121,20 @@ function getScriptTag(appLoc, serverType, streamWebFolder, fileName) {
       ? `/SASJobExecution?_PROGRAM=${appLoc}/${streamWebFolder}`
       : `/SASStoredProcess/?_PROGRAM=${appLoc}/${streamWebFolder}`;
   return `<script src="${storedProcessPath}/${fileName}"></script>`;
+}
+
+function getLinkTag(appLoc, serverType, streamWebFolder, fileName) {
+  const permittedServerTypes = ["SAS9", "SASVIYA"];
+  if (!permittedServerTypes.includes(serverType.toUpperCase())) {
+    throw new Error(
+      "Unsupported server type. Supported types are SAS9 and SASVIYA"
+    );
+  }
+  const storedProcessPath =
+    serverType === "SASVIYA"
+      ? `/SASJobExecution?_PROGRAM=${appLoc}/${streamWebFolder}`
+      : `/SASStoredProcess/?_PROGRAM=${appLoc}/${streamWebFolder}`;
+  return `<link rel="stylesheet" href="${storedProcessPath}/${fileName}" />`;
 }
 
 function getScriptPaths(parsedHtml) {

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -106,14 +106,10 @@ async function createTargetDestinationFolder(name) {
 
 async function getWebServiceContent(fileName, content) {
   const lines = content.split("\n");
-  let serviceContent = `filename ${fileName} temp lrecl=132006;
+  let serviceContent = `${sasjsout}\nfilename ${fileName} temp lrecl=132006;
 data _null_;
 file sasjs;
 `;
-  const sasjsOutLines = sasjsout.split("\n");
-  sasjsOutLines.forEach(line => {
-    serviceContent += `put '${line}';\n`;
-  });
   lines.forEach(line => {
     serviceContent += `put '${line}';\n`;
   });
@@ -124,12 +120,8 @@ file sasjs;
 
 async function createClickMeService(indexHtmlContent, buildTargetName) {
   const lines = indexHtmlContent.split("\n");
-  const sasjsOutLines = sasjsout.split("\n");
-  let clickMeServiceContent =
-    "filename sasjs temp lrecl=132006;\ndata _null_;\nfile sasjs;\n";
-  sasjsOutLines.forEach(line => {
-    clickMeServiceContent += `put '${line}';\n`;
-  });
+  let clickMeServiceContent = `${sasjsout}\nfilename sasjs temp lrecl=132006;\ndata _null_;\nfile sasjs;\n`;
+
   lines.forEach(line => {
     clickMeServiceContent += `put '${line}';\n`;
   });

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -75,6 +75,10 @@ export async function createWebAppServices(targets = []) {
         indexHtml.querySelector("body").innerHTML
       }</body></html>`;
       await createClickMeService(finalIndexHtml, target.name);
+    } else {
+      throw new Error(
+        "webSourcePath has not been specified. Please check your config and try again."
+      );
     }
   });
 }

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -111,11 +111,33 @@ data _null_;
 file sasjs;
 `;
   lines.forEach(line => {
-    serviceContent += `put '${line}';\n`;
+    const chunkedLines = chunk(line);
+    if (chunkedLines.length === 1) {
+      serviceContent += `put '${chunkedLines[0]}';\n`;
+    } else {
+      let combinedLines = "";
+      chunkedLines.forEach((chunkedLine, index) => {
+        let text = `put '${chunkedLine}'`;
+        if (index !== chunkedLines.length - 1) {
+          text += "@;\n";
+        } else {
+          text += ";\n";
+        }
+        combinedLines += text;
+      });
+      serviceContent += combinedLines;
+    }
   });
 
   serviceContent += "\nrun;\n%sasjsout(JS)";
   return serviceContent;
+}
+
+function chunk(text, maxLength = 120) {
+  if (text.length <= maxLength) {
+    return [text];
+  }
+  return text.match(new RegExp(".{1," + maxLength + "}", "g"));
 }
 
 async function createClickMeService(indexHtmlContent, buildTargetName) {

--- a/src/sasjs-web/index.js
+++ b/src/sasjs-web/index.js
@@ -65,6 +65,7 @@ export async function createWebAppServices(targets = []) {
           const scriptTag = getScriptTag(
             target.appLoc,
             target.serverType,
+            target.streamWebFolder,
             fileName
           );
           finalIndexHtml += `\n${scriptTag}`;
@@ -83,7 +84,7 @@ export async function createWebAppServices(targets = []) {
   });
 }
 
-function getScriptTag(appLoc, serverType, fileName) {
+function getScriptTag(appLoc, serverType, streamWebFolder, fileName) {
   const permittedServerTypes = ["SAS9", "SASVIYA"];
   if (!permittedServerTypes.includes(serverType.toUpperCase())) {
     throw new Error(
@@ -92,8 +93,8 @@ function getScriptTag(appLoc, serverType, fileName) {
   }
   const storedProcessPath =
     serverType === "SASVIYA"
-      ? `/SASJobExecution?_PROGRAM=${appLoc}/web`
-      : `/SASStoredProcess?_PROGRAM=${appLoc}/web`;
+      ? `/SASJobExecution?_PROGRAM=${appLoc}/${streamWebFolder}`
+      : `/SASStoredProcess?_PROGRAM=${appLoc}/${streamWebFolder}`;
   return `<script src="${storedProcessPath}/${fileName}"></script>`;
 }
 

--- a/src/sasjs-web/sasjsout.js
+++ b/src/sasjs-web/sasjsout.js
@@ -1,0 +1,26 @@
+export const sasjsout = `%macro sasjsout(type,fref=sasjs);
+%global sysprocessmode;
+%if "&sysprocessmode"="SAS Object Server" %then %do;
+  %if &type=HTML %then %do;
+    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name="_webout.json"
+      contenttype="text/html";
+  %end;
+  %else %if &type=JS %then %do;
+    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name='_webout.js'
+      contenttype='application/javascript';
+  %end;
+%end;
+%else %do;
+
+  %if &type=JS %then %do;
+    %let rc=%sysfunc(stpsrv_header(Content-type,application/javascript));
+  %end;
+%end;
+data _null_;
+  infile &fref RECFM=N;
+  file _webout RECFM=N;
+  input string $CHAR1. @;
+  put string $CHAR1. @;
+run;
+%mend;
+`;

--- a/src/sasjs-web/sasjsout.js
+++ b/src/sasjs-web/sasjsout.js
@@ -1,5 +1,5 @@
 export const sasjsout = `%macro sasjsout(type,fref=sasjs);
-%global sysprocessmode;
+%global sysprocessmode SYS_JES_JOB_URI;
 %if "&sysprocessmode"="SAS Object Server" %then %do;
   %if &type=HTML %then %do;
     filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name="_webout.json"
@@ -9,11 +9,17 @@ export const sasjsout = `%macro sasjsout(type,fref=sasjs);
     filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name='_webout.js'
       contenttype='application/javascript';
   %end;
+  %else %if &type=CSS %then %do;
+    filename _webout filesrvc parenturi="&SYS_JES_JOB_URI" name='_webout.js'
+      contenttype='text/css';
+  %end;
 %end;
 %else %do;
-
   %if &type=JS %then %do;
     %let rc=%sysfunc(stpsrv_header(Content-type,application/javascript));
+  %end;
+  %else %if &type=CSS %then %do;
+    %let rc=%sysfunc(stpsrv_header(Content-type,text/css));
   %end;
 %end;
 data _null_;
@@ -22,5 +28,4 @@ data _null_;
   input string $CHAR1. @;
   put string $CHAR1. @;
 run;
-%mend;
-`;
+%mend;`;

--- a/src/utils/config-utils.js
+++ b/src/utils/config-utils.js
@@ -38,7 +38,7 @@ export async function getBuildTargets() {
   const configuration = await getConfiguration(
     path.join(process.cwd(), "sas", "config.json")
   );
-  return configuration.targets;
+  return configuration.targets ? configuration.targets : [];
 }
 
 export function getMacroCorePath() {


### PR DESCRIPTION
* Build web apps as SAS services using the `sasjs web` command - with one file for each JavaScript or CSS file, and one for the main `index.html`.
* Extend `sasjs build` to take an optional `targetName` argument. If not specified, we will build the first target in the `config.json`.